### PR TITLE
power: Use the correct opcode for STOR_CLK_SCALE_DIS

### DIFF
--- a/power/performance.h
+++ b/power/performance.h
@@ -322,7 +322,7 @@ enum SCHEDULER {
 };
 
 enum STORAGE {
-    STOR_CLK_SCALE_DIS          = 0x42C0C000,
+    STOR_CLK_SCALE_DIS          = 0x42C10000,
 };
 
 enum GPU {


### PR DESCRIPTION
This is actually wrong, 0x42C0C000 is the opcode for SWAP_RATIO and
0x42C10000 is the correct opcode for storage clock scale disabling.

Change-Id: I6b1db525acf061ffe419011acd1f91525a27a35d